### PR TITLE
Fixed docstring typo s/set-min-ns-level/set-ns-min-level/g

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ See [recommended steps](https://github.com/taoensso/encore#recommended-steps-aft
 
 ## Fixes since `v6.0.4`
 
-- 9455cb09 [fix] 1-arg Cljs `set-min-ns-level!` broken
+- 9455cb09 [fix] 1-arg Cljs `set-ns-min-level!` broken
 
 ## New since `v6.0.4`
 

--- a/src/taoensso/timbre.cljc
+++ b/src/taoensso/timbre.cljc
@@ -1109,7 +1109,7 @@
   For convenience, there's also some dedicated helper utils:
 
     - `set-config!`, `merge-config!`        ; Mutate *config*
-    - `set-min-level!`, `set-min-ns-level!` ; Mutate *config* :min-level
+    - `set-min-level!`, `set-ns-min-level!` ; Mutate *config* :min-level
     - `with-config`, `with-merged-config`   ; Bind *config*
     - `with-min-level`                      ; Bind *config* :min-level
 
@@ -1134,7 +1134,7 @@
         #{}, \"*\", \"foo.bar\", \"foo.bar.*\", #{\"foo\" \"bar.*\"},
         {:allow #{\"foo\" \"bar.*\"} :deny #{\"foo.*.bar.*\"}}.
 
-      See also `set-min-ns-level!` for a helper tool.
+      See also `set-ns-min-level!` for a helper tool.
 
     :ns-filter
       Logging will occur only if a logging call's namespace is permitted


### PR DESCRIPTION
I have just noticed a typo in docstring and coudn't pass by.

Take this opportunity to thank you, @ptaoussanis, for all your and other contributors hard work on Open Source!