### PR TITLE
Replace usages of io.aviso/pretty with org.clj-commons/pretty

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
 
   :dependencies
   [[com.taoensso/encore "3.68.0"]
-   [io.aviso/pretty     "1.4.4"]]
+   [org.clj-commons/pretty "2.2.1"]]
 
   :profiles
   {;; :default [:base :system :user :provided :dev]

--- a/src/taoensso/timbre.cljc
+++ b/src/taoensso/timbre.cljc
@@ -7,7 +7,7 @@
    [taoensso.encore :as enc :refer [have have?]]
    [taoensso.timbre.appenders.core :as core-appenders]
 
-   #?(:clj  [io.aviso.exception :as aviso-ex])
+   #?(:clj  [clj-commons.format.exceptions :as pretty-ex])
    #?(:cljs [goog.i18n.DateTimeFormat :as dtf]))
 
   #?(:cljs (:require-macros [taoensso.timbre])))
@@ -499,9 +499,9 @@
   generate output for `:?err` value in log data.
 
   For Clj:
-     Uses `io.aviso/pretty` to return an attractive stacktrace.
+     Uses `org.clj-commons/pretty` to return an attractive stacktrace.
      Options:
-       :stacktrace-fonts ; See `io.aviso.exception/*fonts*`
+       :stacktrace-fonts ; See `clj-commons.format.exceptions/*fonts*`
 
   For Cljs:
      Returns simple stacktrace string."
@@ -531,9 +531,9 @@
                default-stacktrace-fonts)]
 
          (if-let [fonts stacktrace-fonts]
-           (binding [aviso-ex/*fonts* fonts]
-             (do (aviso-ex/format-exception err)))
-           (do   (aviso-ex/format-exception err)))))))
+           (binding [pretty-ex/*fonts* fonts]
+             (do (pretty-ex/format-exception err)))
+           (do (pretty-ex/format-exception err)))))))
 
 (comment
   (default-output-error-fn

--- a/src/taoensso/timbre/appenders/postal.clj
+++ b/src/taoensso/timbre/appenders/postal.clj
@@ -6,7 +6,6 @@
    [clojure.string     :as str]
    [taoensso.encore    :as enc :refer [have have?]]
    [taoensso.timbre    :as timbre]
-   [io.aviso.exception :as aviso-ex]
    [postal.core        :as postal]))
 
 (defn default-subject-fn

--- a/wiki/.gitignore
+++ b/wiki/.gitignore
@@ -1,0 +1,1 @@
+README.md

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -1,0 +1,5 @@
+# Attention!
+
+This wiki is designed for viewing from [here](../../../wiki)!
+
+Viewing from GitHub's file browser will result in **broken links**.


### PR DESCRIPTION
The main issue is that anyone who is using customized fonts (as per the documentation [on the wiki](https://github.com/taoensso/timbre/wiki/1-Getting-started#stacktrace-colors)) will see failures, because the values have changed from strings to keywords.

This may warrant a major version upgrade in Timbre, or at least, a strongly worded note in the change log.