### PR TITLE
Add clojars release shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Supports optional interop with [tools.logging](https://github.com/taoensso/timbr
 
 - `2024-02-26` `v6.5.0` (stable): [release info](../../releases/tag/v6.5.0)
 
+
+[![Clojars Project](https://img.shields.io/clojars/v/com.taoensso/timbre.svg)](https://clojars.org/com.taoensso/timbre)
 [![Main tests][Main tests SVG]][Main tests URL]
 [![Graal tests][Graal tests SVG]][Graal tests URL]
 


### PR DESCRIPTION
It looks like clojars is a common way to communicate the release, and it offers an easy copy-paste for the variety of dependency tracking solutions. This PR adds a link to the clojars page