### PR TITLE
Fix reflection on otlp appender

### DIFF
--- a/src/taoensso/timbre/appenders/community/otlp.clj
+++ b/src/taoensso/timbre/appenders/community/otlp.clj
@@ -80,7 +80,7 @@
            timestamp (.toInstant instant)
            severity  (get timbre->otlp-levels level default-severity)
            arg       (single-map vargs)
-           message   (if-let [msg (:msg arg)] msg (force msg_))
+           ^String message (if-let [msg (:msg arg)] msg (force msg_))
            ?ex-data  (ex-data ?err)
            extra
            (assoc-some-nx context


### PR DESCRIPTION
I'm using on clojure-lsp this appender and noticed this, I believe this affect compatibility with graalvm