### PR TITLE
Allow skipping of appenders when demoting log level via middleware

### DIFF
--- a/src/taoensso/timbre.cljc
+++ b/src/taoensso/timbre.cljc
@@ -491,7 +491,7 @@
              (get config :middleware))]
 
        (when-let [data ?data] ; Not filtered by middleware
-         (let [{:keys [vargs]} data
+         (let [{:keys [level vargs]} data
                data
                (enc/assoc-nx data
                  :msg_ (delay ((protected-fn "Timbre error when calling (msg-fn <data>)"

--- a/test/taoensso/timbre_tests.cljc
+++ b/test/taoensso/timbre_tests.cljc
@@ -92,7 +92,8 @@
    (testing "Levels.appender/basic"
      [(is (map? (log-data "ns" :info {:min-level :info}   {:min-level :info}   [])) "call >= both global and appender")
       (is (nil? (log-data "ns" :info {:min-level :report} {:min-level :info}   [])) "call <  global")
-      (is (nil? (log-data "ns" :info {:min-level :info}   {:min-level :report} [])) "call <  appender")])
+      (is (nil? (log-data "ns" :info {:min-level :info}   {:min-level :report} [])) "call <  appender")
+      (is (nil? (log-data "ns" :warn {:min-level :info :middleware [(fn [_] {:level :info})]} {:min-level :warn}  [])) "call >= both global and appender but demoted to < appender by middleware")])
 
    (testing "Levels.appender/by-ns"
      [(is (map? (log-data "ns" :info {:min-level [["ns" :info]]}  {:min-level :info}          [])) "call >= both global and appender")


### PR DESCRIPTION
When a middleware demotes a log's `:level` below an appender's `:min-level`, that appender will now be skipped. This behavior is consistent with e.g. `:msg_` which was already exposed to the changed log level.

# Review notes

* The patch also affects the calculation of `:hash_`. I'm not 100% sure whether this makes sense.
* The test assertion violates the formatting symmetry relative to the other assertions. Given how much longer it is, it felt a bit off to re-indent all others to match but if you prefer it, I'm happy to adjust.
* Not sure whether the `levels` test is the best place for the assertion but it seemed like a good fit to me.